### PR TITLE
update from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,5 @@ USER appuser
 WORKDIR /app
 COPY --from=builder /output/bin/${APPLICATION_NAME} /app/entrypoint
 
+ENV RUST_BACKTRACE=full
 ENTRYPOINT ["/app/entrypoint"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
       "devDependencies": {
         "@actions/tool-cache": "^2.0.1",
         "@semantic-release/changelog": "^6.0.3",
-        "@semantic-release/commit-analyzer": "^9.0.2",
-        "@semantic-release/github": "^8.1.0",
+        "@semantic-release/commit-analyzer": "^10.0.1",
+        "@semantic-release/github": "^9.0.3",
         "@semantic-release/release-notes-generator": "^11.0.3",
-        "conventional-changelog-conventionalcommits": "^5.0.0",
+        "conventional-changelog-conventionalcommits": "^6.0.0",
         "prettier": "^2.8.8",
         "semantic-release": "^21.0.3",
         "semver": "^7.5.1",
@@ -92,33 +92,33 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.21.4",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
-      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.5.tgz",
+      "integrity": "sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.22.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz",
+      "integrity": "sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.22.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.5.tgz",
+      "integrity": "sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.22.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -172,13 +172,10 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
-      "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
       "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0"
-      },
       "engines": {
         "node": ">= 14"
       }
@@ -236,48 +233,48 @@
       "dev": true
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.0.0.tgz",
+      "integrity": "sha512-NNm6DlYBEyKs9OZvy2Ax9YKn7e0/G7js+/I80icBTHUf6kB/nfaZkdXOF1Z32OaB+LDH6GIYpdYC3Bm3vwX5Ow==",
       "dev": true,
       "dependencies": {
         "@octokit/tsconfig": "^1.0.2",
         "@octokit/types": "^9.2.3"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
         "@octokit/core": ">=4"
       }
     },
     "node_modules/@octokit/plugin-retry": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-4.1.6.tgz",
-      "integrity": "sha512-obkYzIgEC75r8+9Pnfiiqy3y/x1bc3QLE5B7qvv9wi9Kj0R5tGQFC6QMBg1154WQ9lAVypuQDGyp3hNpp15gQQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.2.tgz",
+      "integrity": "sha512-/Z7rWLCfjwmaVdyFuMkZoAnhfrvYgtvDrbO2d6lv7XrvJa8gFGB5tLUMngfuyMBfDCc5B9+EVu7IkQx5ebVlMg==",
       "dev": true,
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
         "@octokit/core": ">=3"
       }
     },
     "node_modules/@octokit/plugin-throttling": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-5.2.3.tgz",
-      "integrity": "sha512-C9CFg9mrf6cugneKiaI841iG8DOv6P5XXkjmiNNut+swePxQ7RWEdAZRp5rJoE1hjsIqiYcKa/ZkOQ+ujPI39Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.1.tgz",
+      "integrity": "sha512-C5h2lT+LEF4SqmbB1RbMn1PhBlHKkZoqMGS39woJr0XJ+getmOcUvrytTtS4NOn1zh/iT1ByRWYwwmFYznv83w==",
       "dev": true,
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "bottleneck": "^2.15.3"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       },
       "peerDependencies": {
         "@octokit/core": "^4.0.0"
@@ -389,24 +386,24 @@
       }
     },
     "node_modules/@semantic-release/commit-analyzer": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
-      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.1.tgz",
+      "integrity": "sha512-9ejHzTAijYs9z246sY/dKBatmOPcd0GQ7lH4MgLCkv1q4GCiDZRkjHJkaQZXZVaK7mJybS+sH3Ng6G8i3pYMGQ==",
       "dev": true,
       "dependencies": {
-        "conventional-changelog-angular": "^5.0.0",
-        "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
+        "conventional-changelog-angular": "^6.0.0",
+        "conventional-commits-filter": "^3.0.0",
+        "conventional-commits-parser": "^4.0.0",
         "debug": "^4.0.0",
         "import-from": "^4.0.0",
-        "lodash": "^4.17.4",
+        "lodash-es": "^4.17.21",
         "micromatch": "^4.0.2"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
+        "semantic-release": ">=20.1.0"
       }
     },
     "node_modules/@semantic-release/error": {
@@ -419,34 +416,97 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.1.0.tgz",
-      "integrity": "sha512-erR9E5rpdsz0dW1I7785JtndQuMWN/iDcemcptf67tBNOmBUN0b2YNOgcjYUnBpgRpZ5ozfBHrK7Bz+2ets/Dg==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.0.3.tgz",
+      "integrity": "sha512-X6gq4USKVlCxPwIIyXb99jU7gwVWlnsKOevs+OyABRdoqc+OIRITbFmrrYU3eE1vGMGk+Qu/GAoLUQQQwC3YOA==",
       "dev": true,
       "dependencies": {
         "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^6.1.2",
-        "@octokit/plugin-retry": "^4.1.3",
-        "@octokit/plugin-throttling": "^5.2.3",
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^3.0.0",
-        "debug": "^4.0.0",
-        "dir-glob": "^3.0.0",
-        "fs-extra": "^11.0.0",
-        "globby": "^11.0.0",
+        "@octokit/plugin-paginate-rest": "^7.0.0",
+        "@octokit/plugin-retry": "^5.0.0",
+        "@octokit/plugin-throttling": "^6.0.0",
+        "@semantic-release/error": "^4.0.0",
+        "aggregate-error": "^4.0.1",
+        "debug": "^4.3.4",
+        "dir-glob": "^3.0.1",
+        "globby": "^13.1.4",
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.0",
         "issue-parser": "^6.0.0",
-        "lodash": "^4.17.4",
+        "lodash-es": "^4.17.21",
         "mime": "^3.0.0",
-        "p-filter": "^2.0.0",
-        "url-join": "^4.0.0"
+        "p-filter": "^3.0.0",
+        "url-join": "^5.0.0"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "semantic-release": ">=18.0.0-beta.1"
+        "semantic-release": ">=20.1.0"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@semantic-release/github/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@semantic-release/npm": {
@@ -658,49 +718,6 @@
         "semantic-release": ">=20.1.0"
       }
     },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-changelog-angular": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
-      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
-      "dev": true,
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-filter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
-      "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
-      "dev": true,
-      "dependencies": {
-        "lodash.ismatch": "^4.4.0",
-        "modify-values": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@semantic-release/release-notes-generator/node_modules/conventional-commits-parser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
-      "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
-      "dev": true,
-      "dependencies": {
-        "is-text-path": "^1.0.1",
-        "JSONStream": "^1.3.5",
-        "meow": "^8.1.2",
-        "split2": "^3.2.2"
-      },
-      "bin": {
-        "conventional-commits-parser": "cli.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -809,15 +826,6 @@
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
       "integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
       "dev": true
-    },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/arrify": {
       "version": "1.0.1",
@@ -988,30 +996,27 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
-      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-6.0.0.tgz",
+      "integrity": "sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==",
       "dev": true,
       "dependencies": {
-        "compare-func": "^2.0.0",
-        "q": "^1.5.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz",
-      "integrity": "sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-6.0.0.tgz",
+      "integrity": "sha512-pOQWvJ2se8UmGj3Vz5NzhljdgHvGow6ATZ7pM0TZqGekAfwgJkr3YQ9ZbooB4VIh35KS/cpfIgVrLoqLNvFNYg==",
       "dev": true,
       "dependencies": {
-        "compare-func": "^2.0.0",
-        "lodash": "^4.17.15",
-        "q": "^1.5.1"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/conventional-changelog-writer": {
@@ -1035,7 +1040,16 @@
         "node": ">=14"
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/conventional-commits-filter": {
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/conventional-commits-filter": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
       "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
@@ -1048,46 +1062,22 @@
         "node": ">=14"
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/conventional-commits-filter": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.7.tgz",
-      "integrity": "sha512-ASS9SamOP4TbCClsRHxIHXRfcGCnIoQqkvAzCSbZzTFLfcTqJVugB0agRgsEELsqaeWgsXv513eS116wnlSSPA==",
-      "dev": true,
-      "dependencies": {
-        "lodash.ismatch": "^4.4.0",
-        "modify-values": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/conventional-commits-parser": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
-      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-4.0.0.tgz",
+      "integrity": "sha512-WRv5j1FsVM5FISJkoYMR6tPk07fkKT0UodruX4je86V4owk451yjXAKzKAPOs9l7y59E2viHUS9eQ+dfUA9NSg==",
       "dev": true,
       "dependencies": {
         "is-text-path": "^1.0.1",
-        "JSONStream": "^1.0.4",
-        "lodash": "^4.17.15",
-        "meow": "^8.0.0",
-        "split2": "^3.0.0",
-        "through2": "^4.0.0"
+        "JSONStream": "^1.3.5",
+        "meow": "^8.1.2",
+        "split2": "^3.2.2"
       },
       "bin": {
         "conventional-commits-parser": "cli.js"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/core-util-is": {
@@ -1527,16 +1517,6 @@
         "through2": "~2.0.0"
       }
     },
-    "node_modules/git-log-parser/node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -1550,20 +1530,19 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
+      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
       "dev": true,
       "dependencies": {
-        "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
+        "fast-glob": "^3.2.11",
         "ignore": "^5.2.0",
         "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "slash": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5839,15 +5818,18 @@
       }
     },
     "node_modules/p-filter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-2.1.0.tgz",
-      "integrity": "sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-3.0.0.tgz",
+      "integrity": "sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==",
       "dev": true,
       "dependencies": {
-        "p-map": "^2.0.0"
+        "p-map": "^5.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-is-promise": {
@@ -5890,12 +5872,73 @@
       }
     },
     "node_modules/p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
+      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map/node_modules/aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map/node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-reduce": {
@@ -6109,16 +6152,6 @@
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
-      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -6388,105 +6421,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/semantic-release/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-7.0.0.tgz",
-      "integrity": "sha512-NNm6DlYBEyKs9OZvy2Ax9YKn7e0/G7js+/I80icBTHUf6kB/nfaZkdXOF1Z32OaB+LDH6GIYpdYC3Bm3vwX5Ow==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/tsconfig": "^1.0.2",
-        "@octokit/types": "^9.2.3"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=4"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@octokit/plugin-retry": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-5.0.0.tgz",
-      "integrity": "sha512-mfON7q30NLdivuJktZuSP6I4/WPMjc/bcoxcHEWXd4esedHTqQpp3OUq2NzD2+M+J6o33zYDtJTl4qtRYh8HQQ==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": ">=3"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@octokit/plugin-throttling": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-6.0.0.tgz",
-      "integrity": "sha512-RdKkzD8X/T17KJmEHTsZ5Ztj7WGNpxsJAIyR1bgvkoyar+cDrIRZMsP15r8JRB1QI/LN2F/stUs5/kMVaYXS9g==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "bottleneck": "^2.15.3"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@octokit/core": "^4.0.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@semantic-release/commit-analyzer": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-10.0.0.tgz",
-      "integrity": "sha512-/Uolz2+G+VRjP0eudAn0ldnC/VkSHzlctUdeEXL7ys7E6mLSFZdwdsR5pKDlTIgDJq4eYlshOZpwBNrmqrNajg==",
-      "dev": true,
-      "dependencies": {
-        "conventional-changelog-angular": "^5.0.0",
-        "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
-        "debug": "^4.0.0",
-        "import-from": "^4.0.0",
-        "lodash-es": "^4.17.21",
-        "micromatch": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=20.1.0"
-      }
-    },
-    "node_modules/semantic-release/node_modules/@semantic-release/github": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.0.2.tgz",
-      "integrity": "sha512-FDwR9Tkz14MR/HF6srbHDuqLPUI0GmPgn4tkjfPi45/1oZedqEXC3TqSHK3+ykJmWj1sXgs94zwGI10VR5o6kg==",
-      "dev": true,
-      "dependencies": {
-        "@octokit/core": "^4.2.1",
-        "@octokit/plugin-paginate-rest": "^7.0.0",
-        "@octokit/plugin-retry": "^5.0.0",
-        "@octokit/plugin-throttling": "^6.0.0",
-        "@semantic-release/error": "^3.0.0",
-        "aggregate-error": "^4.0.1",
-        "debug": "^4.3.4",
-        "dir-glob": "^3.0.1",
-        "globby": "^13.1.4",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.0",
-        "issue-parser": "^6.0.0",
-        "lodash-es": "^4.17.21",
-        "mime": "^3.0.0",
-        "p-filter": "^3.0.0",
-        "url-join": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "semantic-release": ">=20.1.0"
-      }
-    },
     "node_modules/semantic-release/node_modules/aggregate-error": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
@@ -6542,25 +6476,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/semantic-release/node_modules/globby": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
-      "dev": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.11",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/semantic-release/node_modules/hosted-git-info": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
@@ -6592,57 +6507,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/semantic-release/node_modules/p-filter": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-filter/-/p-filter-3.0.0.tgz",
-      "integrity": "sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==",
-      "dev": true,
-      "dependencies": {
-        "p-map": "^5.1.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/p-map": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
-      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semantic-release/node_modules/url-join": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
-      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/semver": {
@@ -6768,12 +6632,15 @@
       }
     },
     "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/source-map": {
@@ -7058,26 +6925,13 @@
       "dev": true
     },
     "node_modules/through2": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-      "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "dev": true,
       "dependencies": {
-        "readable-stream": "3"
-      }
-    },
-    "node_modules/through2/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dev": true,
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
       }
     },
     "node_modules/to-regex-range": {
@@ -7181,10 +7035,13 @@
       }
     },
     "node_modules/url-join": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
-      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
-      "dev": true
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+      "integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "devDependencies": {
     "@actions/tool-cache": "^2.0.1",
     "@semantic-release/changelog": "^6.0.3",
-    "@semantic-release/commit-analyzer": "^9.0.2",
-    "@semantic-release/github": "^8.1.0",
+    "@semantic-release/commit-analyzer": "^10.0.1",
+    "@semantic-release/github": "^9.0.3",
     "@semantic-release/release-notes-generator": "^11.0.3",
-    "conventional-changelog-conventionalcommits": "^5.0.0",
+    "conventional-changelog-conventionalcommits": "^6.0.0",
     "prettier": "^2.8.8",
     "semantic-release": "^21.0.3",
     "semver": "^7.5.1",


### PR DESCRIPTION
- chore(deps): update rust to v1.68.2
- chore(deps): update alpine docker tag to v3.17.3
- chore(deps): update npm to >=9.6.3
- chore(deps): update returntocorp/semgrep docker tag to v1.16.0
- chore(deps): update dependency semantic-release to ^21.0.1
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to 601b3b8
- chore(deps): update returntocorp/semgrep docker tag to v1.17.0
- chore(deps): update github/codeql-action action to v2.2.10
- chore(deps): update npm to >=9.6.4
- chore(deps): update returntocorp/semgrep docker tag to v1.17.1
- chore(deps): update actions/github-script action to v6.4.1
- chore(deps): update github/codeql-action action to v2.2.11
- chore(deps): lock file maintenance
- chore(deps): update dependency semver to ^7.4.0
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.6.2
- chore(deps): update codecov/codecov-action action to v3.1.2
- chore(deps): update actions/checkout action to v3.5.1
- chore(deps): update rust:1.68.2 docker digest to b4bf530
- chore(deps): update rust:1.68.2 docker digest to 346a6ec
- chore(deps): update node.js to >=v18.16.0
- chore(deps): update actions/checkout action to v3.5.2
- chore(deps): update github/codeql-action action to v2.2.12
- chore(deps): update returntocorp/semgrep docker tag to v1.18.0
- chore(deps): lock file maintenance
- chore(deps): update dependency semver to ^7.5.0
- chore(deps): update docker/metadata-action action to v4.4.0
- chore(deps): update npm to >=9.6.5
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.7.0
- chore(deps): update codecov/codecov-action action to v3.1.3
- chore(deps): update rust to v1.69.0
- chore(deps): update rust:1.69.0 docker digest to 9d78a0a
- chore(deps): update github/codeql-action action to v2.3.0
- chore(deps): update returntocorp/semgrep docker tag to v1.19.0
- chore(deps): update dependency prettier to ^2.8.8
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to fdcde64
- chore(deps): update github/codeql-action action to v2.3.1
- chore(deps): update github/codeql-action action to v2.3.2
- chore(deps): update returntocorp/semgrep docker tag to v1.20.0
- chore(deps): update dependency semantic-release to ^21.0.2
- chore(deps): update rust:1.69.0 docker digest to e6187ab
- chore(deps): update rust:1.69.0 docker digest to ac46609
- chore(deps): update npm to >=9.6.6
- chore(deps): update rust:1.69.0 docker digest to 5fb0729
- chore(deps): update rust:1.69.0 docker digest to af08886
- chore(deps): update rust:1.69.0 docker digest to ee5de98
- chore(deps): update github/codeql-action action to v2.3.3
- chore(deps): update returntocorp/semgrep docker tag to v1.21.0
- chore(deps): update dependency @semantic-release/release-notes-generator to v11
- chore(deps): lock file maintenance
- chore(deps): update alpine docker tag to v3.18.0
- chore(deps): update dependency semver to ^7.5.1
- chore(deps): lock file maintenance
- chore(deps): update codecov/codecov-action action to v3.1.4
- chore(deps): update returntocorp/semgrep docker tag to v1.22.0
- chore(deps): update npm to >=9.6.7
- chore(deps): lock file maintenance
- chore(deps): update rust:1.69.0 docker digest to 4c1cab3
- chore(deps): update rust:1.69.0 docker digest to abebc02
- chore(deps): update rust:1.69.0 docker digest to 3d8684d
- chore(deps): update rust:1.69.0 docker digest to c2dcc19
- chore(deps): update returntocorp/semgrep docker tag to v1.23.0
- chore(deps): update github/codeql-action action to v2.3.4
- chore(deps): update github/codeql-action action to v2.3.5
- chore(deps): update dependency @semantic-release/github to ^8.0.8
- chore(deps): update github/codeql-action action to v2.3.6
- chore(deps): update returntocorp/semgrep docker tag to v1.24.1
- chore(deps): update semantic-release monorepo
- chore(deps): update dependency semantic-release to ^21.0.3
- chore(deps): update rust to v1.70.0
- chore(deps): update rust:1.70.0 docker digest to cf5513b
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.25.0
- chore(deps): update docker/login-action action to v2.2.0
- chore(deps): update npm to >=9.7.1
- chore(deps): update docker/metadata-action action to v4.5.0
- chore(deps): update dependency @semantic-release/release-notes-generator to ^11.0.3
- chore(deps): update mcr.microsoft.com/devcontainers/rust:0-1-bullseye docker digest to b723b13
- chore(deps): update docker/setup-buildx-action action to v2.6.0
- chore(deps): update semantic-release monorepo
- chore(deps): update dependency conventional-changelog-conventionalcommits to v6
- fix: set maximum backtrace
