### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,12 +308,11 @@ jobs:
         run: |
           grcov $(find profiling -name "profile-*.profraw" -print) --source-dir . --binary-path ./target/debug/ --output-type lcov --branch --ignore-not-existing --llvm --keep-only "src/**" --keep-only "tests/**" --output-path ./reports/lcov.info
 
-      - name: Upload to CodeCov
-        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@v2.2.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: reports
-          fail_ci_if_error: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: reports/lcov.info
 
       - name: Fail if tests failed
         shell: bash

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,8 +22,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "advent_of_code_2022=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,advent_of_code_2022=trace"
             }
         },
         {
@@ -45,8 +45,8 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "1",
-                "RUST_LOG": "advent_of_code_2022=trace"
+                "RUST_BACKTRACE": "full",
+                "RUST_LOG": "trace,advent_of_code_2022=trace"
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,7 +18,7 @@
         {
             "type": "cargo",
             "command": "build",
-            "args": [],
+            "args": ["--workspace", "--all-targets", "--all-features"],
             "problemMatcher": ["$rustc"],
             "group": "build",
             "label": "Rust: cargo build"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,25 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "advent-of-code-2022"
 version = "0.0.0-development"
 dependencies = [
+ "color-eyre",
  "nu-ansi-term",
  "regex",
 ]
@@ -20,10 +36,107 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a667583cca8c4f8436db8de46ea8233c42a7d9ae424a82d338f2e4675229204"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.147"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -33,6 +146,33 @@ checksum = "db8e83967c32f9210ce85ac7e9c4b731048c1f51c4262e08bad01af30097a424"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "regex"
@@ -62,6 +202,79 @@ name = "regex-syntax"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab07dc67230e4a4718e70fd5c20055a4334b121f1f9db8fe63ef39ce9b8c846"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,16 @@ coverage = []
 [dependencies]
 nu-ansi-term = "0.48.0"
 regex = "1.9.1"
-
+color-eyre = "0.6.2"
+# reqwest = { version = "0.11.5", features = ["json"] }
+# serde_json = "1.0.68"
+# serde = { version = "1.0.130", features = ["derive"] }
+# futures = "0.3.17"
+# tokio = { version = "1.12.0", features = ["full"] }
+# log = "0.4.14"
+# env_logger = "0.9.0"
+# serde_yaml = "0.8.21"
+# clap = { version = "3.0.14", features = ["derive"] }
 
 # We compile the Docker container with musl to get a static library. Smaller, faster.
 # BUT that means that we need to include openssl

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,9 @@ fn print_answer(day: u32, part: u32, result: &str) {
     println!("Answer to Day {}, part {} is ... {}", day, part, result);
 }
 
-fn main() {
+fn main() -> Result<(), color_eyre::Report> {
+    color_eyre::install()?;
+
     let mut day: u32 = 1;
 
     let solutions: Vec<Box<dyn Day>> = vec![
@@ -64,4 +66,6 @@ fn main() {
 
         day += 1;
     }
+
+    Ok(())
 }

--- a/update-name.sh
+++ b/update-name.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+
+NEW_NAME=$1
+
+FILTERED_NAME=$(echo "${NEW_NAME}" | sed -e "s/[a-z0-9-]//g")
+
+
+echo "New name = ${NEW_NAME}"
+
+
+if [[ ${#FILTERED_NAME} != 0 ]]; then
+    echo "Name only allows [a-z0-9-], found ${FILTERED_NAME} (length = ${#FILTERED_NAME})"
+    exit 1
+fi
+
+
+NEW_NAME_WITH_UNDERSCORE=$(echo "${NEW_NAME}" | sed -e "s/-/_/g")
+
+echo "New name with underscore = ${NEW_NAME_WITH_UNDERSCORE}"
+
+
+P1="rust-end-to-end-"
+OLD_NAME="${P1}application"
+OLD_NAME_WITH_UNDERSCORE=$(echo "${OLD_NAME}" | sed -e "s/-/_/g")
+
+echo ${OLD_NAME_WITH_UNDERSCORE}
+
+
+rg --hidden --files-with-matches ${OLD_NAME} | xargs -i sed -i "s/${OLD_NAME}/${NEW_NAME}/g" {}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE}
+rg --hidden --files-with-matches ${OLD_NAME_WITH_UNDERSCORE} | xargs -i sed -i "s/${OLD_NAME_WITH_UNDERSCORE}/${NEW_NAME_WITH_UNDERSCORE}/g" {}


### PR DESCRIPTION
- chore(deps): update alpine:3.18.2 docker digest to c7431a7
- chore(deps): update alpine:3.18.2 docker digest to 5246eec
- chore(deps): update alpine:3.18.2 docker digest to 82d1e9d
- chore(deps): update mcr.microsoft.com/devcontainers/rust docker tag to v1
- chore(deps): update dependency semver to ^7.5.2
- fix: also do RUST_BACKTRACE=full for debugging
- chore(deps): update dependency conventional-changelog-conventionalcommits to ^6.1.0
- chore(deps): lock file maintenance
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.8.0
- chore(deps): update node.js to >=v18.16.1
- chore(deps): update returntocorp/semgrep docker tag to v1.28.0
- chore(deps): update github/codeql-action action to v2.20.1
- chore(deps): update npm to >=9.7.2
- chore(deps): update dependency semver to ^7.5.3
- fix: build all with tests too
- fix: trace for all, not just the app
- fix: default is to use color-eyre
- fix: trace for run and test
- chore(deps): lock file maintenance
- chore(deps): update returntocorp/semgrep docker tag to v1.29.0
- chore(deps): update docker/setup-buildx-action action to v2.8.0
- chore(deps): update returntocorp/semgrep docker tag to v1.30.0
- chore(deps): update dependency semantic-release to ^21.0.6
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.20.2
- chore(deps): update rust:1.70.0 docker digest to d3283ba
- chore(deps): update rust:1.70.0 docker digest to a8d4f44
- chore(deps): update rust:1.70.0 docker digest to 28ee882
- chore(deps): update dependency @semantic-release/release-notes-generator to ^11.0.4
- chore(deps): update dependency semantic-release to ^21.0.7
- chore(deps): update rust:1.70.0 docker digest to dbdf889
- chore(deps): update actions/setup-node action to v3.7.0
- chore(deps): update npm to >=9.8.0
- chore(deps): update github/codeql-action action to v2.20.3
- chore(deps): update dependency prettier to v3
- fix: add update-name script
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to b732d41
- chore(deps): update docker/setup-buildx-action action to v2.9.0
- chore(deps): update returntocorp/semgrep docker tag to v1.31.1
- chore(deps): update dependency semver to ^7.5.4
- chore(deps): update returntocorp/semgrep docker tag to v1.31.2
- chore(deps): lock file maintenance
- chore(deps): update docker/setup-buildx-action action to v2.9.1
- fix: Coveralls as CodeCov keeps on failing
- fix: specify version, Renovate will pin it
- chore(deps): update github/codeql-action action to v2.20.4
