### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,9 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Check if we actually made changes
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # tag=v2.11.1
@@ -80,8 +82,9 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
+          show-progress: false
           fetch-depth: 0
 
       - name: Cache dependencies
@@ -154,7 +157,9 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Cache dependencies
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -193,7 +198,9 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Cache dependencies
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -230,7 +237,9 @@ jobs:
     if: fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Cache dependencies
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -337,7 +346,9 @@ jobs:
       fromJSON(needs.changes.outputs.code) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Cache dependencies
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
@@ -364,7 +375,7 @@ jobs:
       - name: Run Clippy for GitHub Actions report
         uses: actions-rs-plus/clippy-check@9035ac35de400d5b7d37b4ce176ebd153e424d29 # v2
         with:
-          args: --workspace --all-targets --all-features -- --deny clippy::all --deny clippy::pedantic --deny clippy::cargo
+          args: --workspace --all-targets --all-features
 
   docker-build:
     name: Build Docker container
@@ -374,7 +385,9 @@ jobs:
     # if: ... is not needed because calculate-version will not run if we disable building the docker container
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Set the Cargo.toml version before we copy in the data into the Docker container
         shell: bash

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -18,8 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
+          show-progress: false
           fetch-depth: 0
 
       - name: Cache dependencies

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Setup Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,9 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
+          show-progress: false
           token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
 
       - name: Setup Node.js

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -55,8 +55,9 @@ jobs:
       fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
+          show-progress: false
           fetch-depth: 2
 
       - name: Find out if current commit is a merge

--- a/.github/workflows/semantic-tags-after-release.yml
+++ b/.github/workflows/semantic-tags-after-release.yml
@@ -24,7 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Setup Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
@@ -117,7 +119,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Setup Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -23,7 +23,9 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Run semgrep
         shell: bash

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -27,7 +27,9 @@ jobs:
           exit 1
 
       - name: Checkout
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          show-progress: false
 
       - name: Setup Node.js
         uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,9 +22,10 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "full",
-                "RUST_LOG": "trace,advent_of_code_2022=trace"
-            }
+                "RUST_BACKTRACE": "1",
+                "RUST_LOG": "debug,advent_of_code_2022=trace"
+            },
+            "terminal": "console"
         },
         {
             "type": "lldb",
@@ -45,9 +46,34 @@
             "args": [],
             "cwd": "${workspaceFolder}",
             "env": {
-                "RUST_BACKTRACE": "full",
-                "RUST_LOG": "trace,advent_of_code_2022=trace"
-            }
+                "RUST_BACKTRACE": "1",
+                "RUST_LOG": "debug,advent_of_code_2022=trace"
+            },
+            "terminal": "console"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Debug integration test 'integration_tests'",
+            "cargo": {
+                "args": [
+                    "test",
+                    "--no-run",
+                    "--test=integration_tests",
+                    "--package=advent-of-code-2022"
+                ],
+                "filter": {
+                    "name": "integration_tests",
+                    "kind": "test"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "RUST_BACKTRACE": "1",
+                "RUST_LOG": "debug,advent_of_code_2022=trace"
+            },
+            "terminal": "console"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -34,18 +34,7 @@
         {
             "type": "cargo",
             "command": "clippy",
-            "args": [
-                "--workspace",
-                "--all-targets",
-                "--all-features",
-                "--",
-                "--deny",
-                "clippy::all",
-                "--deny",
-                "clippy::pedantic",
-                "--deny",
-                "clippy::cargo"
-            ],
+            "args": ["--workspace", "--all-targets", "--all-features"],
             "problemMatcher": ["$rustc"],
             "group": "build",
             "label": "Rust: cargo clippy"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,16 @@
-#![cfg_attr(not(debug_assertions), deny(warnings))]
 #![deny(clippy::all)]
 #![deny(clippy::pedantic)]
 #![deny(clippy::cargo)]
+#![deny(warnings)]
+// exceptions
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_possible_wrap)]
 #![allow(clippy::cast_sign_loss)]
-#![allow(clippy::too_many_lines)]
 #![allow(clippy::let_and_return)]
+#![allow(clippy::too_many_lines)]
 #![allow(clippy::uninlined_format_args)]
-#![forbid(non_ascii_idents)]
+#![deny(let_underscore_drop)]
+#![deny(non_ascii_idents)]
 
 use shared::Day;
 


### PR DESCRIPTION
- chore(deps): update dependency @semantic-release/github to ^9.0.4
- chore(deps): lock file maintenance
- chore(deps): update node.js to >=v18.17.0
- chore(deps): update github/codeql-action action to v2.21.0
- chore(deps): update npm to >=9.8.1
- chore(deps): update returntocorp/semgrep docker tag to v1.33.0
- chore(deps): update returntocorp/semgrep docker tag to v1.33.1
- chore(deps): update returntocorp/semgrep docker tag to v1.33.2
- chore(deps): lock file maintenance
- chore(deps): update github/codeql-action action to v2.21.1
- chore(deps): update returntocorp/semgrep docker tag to v1.34.0
- chore(deps): update rust:1.71.0 docker digest to a93ade4
- chore(deps): update github/codeql-action action to v2.21.2
- chore(deps): update rust:1.71.0 docker digest to 92d62e4
- chore(deps): update returntocorp/semgrep docker tag to v1.34.1
- chore(deps): update rust:1.71.0 docker digest to f4465d2
- chore(deps): lock file maintenance
- chore(deps): update dependency serialize-error to ^11.0.1
- chore(deps): update dependency prettier to ^3.0.1
- chore(deps): update enricomi/publish-unit-test-result-action action to v2.9.0
- chore(deps): update mcr.microsoft.com/devcontainers/rust:1-1-bullseye docker digest to cf9b9da
- chore(deps): update rust docker tag to v1.71.1
- chore(deps): lock file maintenance
- chore(deps): update alpine docker tag to v3.18.3
- chore(deps): update github/codeql-action action to v2.21.3
- chore(deps): update node.js to >=v18.17.1
- chore(deps): update returntocorp/semgrep docker tag to v1.35.0
- chore(deps): lock file maintenance
- chore(deps): update actions/setup-node action to v3.8.0
- chore(deps): update github/codeql-action action to v2.21.4
- chore(deps): update returntocorp/semgrep docker tag to v1.36.0
- chore(deps): update dependency prettier to ^3.0.2
- chore(deps): update rust:1.71.1 docker digest to 69dcbc9
- chore(deps): update rust:1.71.1 docker digest to b988926
- chore(deps): update actions/setup-node action to v3.8.1
- chore(deps): update dependency semantic-release to ^21.0.9
- chore(deps): lock file maintenance
- chore(deps): update dependency semantic-release to ^21.1.0
- chore(deps): update dependency semantic-release to ^21.1.1
- chore(deps): update actions/checkout action to v3.6.0
- chore(deps): update rust to v1.72.0
- chore(deps): update returntocorp/semgrep docker tag to v1.37.0
- chore(deps): update dependency serialize-error to ^11.0.2
- chore(deps): update dependency @semantic-release/release-notes-generator to ^11.0.5
- chore(deps): update dependency @semantic-release/commit-analyzer to ^10.0.2
- chore(deps): update dependency conventional-changelog-conventionalcommits to v7
- chore(deps): lock file maintenance
- chore(deps): update semantic-release monorepo
- chore(deps): update docker/setup-buildx-action action to v2.10.0
- chore(deps): update github/codeql-action action to v2.21.5
- chore(deps): update semantic-release monorepo
- chore(deps): update dependency prettier to ^3.0.3
- chore(deps): update returntocorp/semgrep docker tag to v1.38.0
- fix: we don't use .idea config
- fix: better defaults
- chore(deps): update returntocorp/semgrep docker tag to v1.38.1
- fix: consolidate clippy & rust config on top of main, all the rest causes duplication
- chore(deps): update npm to v10
- chore(deps): update returntocorp/semgrep docker tag to v1.38.2
- chore(deps): update returntocorp/semgrep docker tag to v1.38.3
- chore(deps): update returntocorp/semgrep:1.38.3 docker digest to 4bdf124
- chore(deps): lock file maintenance
- chore(deps): update coverallsapp/github-action action to v2.2.2
- chore(deps): update actions/checkout action to v4
- fix: don't show progress
