### PR TITLE
clippy 1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "advent-of-code-2022"
 # don't change this, it's updated before an actual build by update-version.sh
 version = "0.0.0-development"
 edition = "2024"
-rust-version = "1.85.1"
+rust-version = "1.86.0"
 authors = ["Kristof Mattei"]
 description = "Advent of Code 2022"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ perf = "warn"
 style = "warn"
 suspicious = "warn"
 
+needless_continue = { level = "allow", priority = 127 }
 # this one causes confusion when combining variables (`foo`) and
 # dereferenced variables (`foo.bar`). The latter cannot be inlined
 # so we don't inline anything

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"
 components = ["cargo", "clippy", "rustfmt"]
 profile = "minimal"


### PR DESCRIPTION
- **chore(deps): update rust to v1.86.0**
- **chore: clippy 1.86 fixes**
