### PR TITLE
update from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN rm -f /etc/apt/apt.conf.d/docker-clean \
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
     apt-get update \
-    && apt-get --no-install-recommends install --yes \
+    && apt-get upgrade --yes \
+    && apt-get install --no-install-recommends --yes \
         build-essential \
         musl-dev \
         musl-tools


### PR DESCRIPTION
- **chore(deps): lock file maintenance**
- **chore(deps): update softprops/action-gh-release action to v2.3.0**
- **chore(deps): update softprops/action-gh-release action to v2.3.2**
- **chore(deps): update returntocorp/semgrep docker tag to v1.124.1**
- **chore(deps): update rust:1.87.0 docker digest to b571d7b**
- **chore: upgrade before installing**
