### PR TITLE
update from upstream

### DIFF
--- a/.github/scripts/cleanup-containers.sh
+++ b/.github/scripts/cleanup-containers.sh
@@ -96,7 +96,8 @@ else
     api_path="/users/$user"
 fi
 
-registry_base="ghcr.io/$target/$package_name"
+# Docker references must be lowercase
+registry_base="ghcr.io/${target,,}/${package_name,,}"
 
 # Check if gh CLI is installed and authenticated
 if ! command -v gh &> /dev/null; then
@@ -124,15 +125,15 @@ if ! command -v jq &> /dev/null; then
 fi
 
 # Check if skopeo or docker is available for manifest inspection
+# Without manifest inspection every untagged platform-specific image looks orphaned, so refuse to run
 manifest_tool=""
 if command -v skopeo &> /dev/null; then
     manifest_tool="skopeo"
 elif command -v docker &> /dev/null; then
     manifest_tool="docker"
 else
-    echo "Warning: Neither 'skopeo' nor 'docker' found. Cannot inspect multi-platform manifests." >&2
-    echo "         Platform-specific images may be incorrectly deleted." >&2
-    echo "         Install 'skopeo' or 'docker' to fix this." >&2
+    echo "Error: Neither 'skopeo' nor 'docker' found. Cannot inspect multi-platform manifests, refusing to delete anything." >&2
+    exit 1
 fi
 
 # ========== UTILITY FUNCTIONS ==========
@@ -244,36 +245,46 @@ get_first_tag() {
 
 # Fetch manifest and extract referenced digests (for multi-platform images)
 # Returns newline-separated list of sha256 digests (without 'sha256:' prefix)
+# Fails when the manifest cannot be fetched, an empty result only means "not an index"
 get_referenced_digests() {
     local image_ref="$1"
 
-    if [[ -z "$manifest_tool" ]]; then
-        return 0
-    fi
-
     local manifest=""
     if [[ "$manifest_tool" == "skopeo" ]]; then
-        manifest=$(skopeo inspect --raw "docker://${image_ref}" 2> /dev/null) || return 0
+        manifest=$(skopeo inspect --raw "docker://${image_ref}") || return 1
     elif [[ "$manifest_tool" == "docker" ]]; then
-        manifest=$(docker buildx imagetools inspect --raw "$image_ref" 2> /dev/null) || return 0
+        manifest=$(docker buildx imagetools inspect --raw "$image_ref") || return 1
     fi
 
     if [[ -z "$manifest" ]]; then
+        return 1
+    fi
+
+    if echo "$manifest" | jq --exit-status '.manifests' > /dev/null 2>&1; then
+        echo "$manifest" | jq --raw-output '.manifests[].digest // empty' | sed 's/^sha256://'
+    fi
+}
+
+# Protect every digest referenced by the manifest of the version's first tag
+# An uninspectable manifest aborts the run: treating it as "no children" would delete live platform-specific images
+protect_referenced_digests() {
+    local tags_json="$1"
+    local first_tag ref_digest ref_digests
+
+    first_tag=$(get_first_tag "$tags_json")
+    if [[ -z "$first_tag" ]]; then
         return 0
     fi
 
-    # Check if this is a manifest list/index (multi-platform)
-    local media_type
-    media_type=$(echo "$manifest" | jq --raw-output '.mediaType // .schemaVersion // empty')
-
-    # Multi-platform manifest indicators:
-    # - application/vnd.oci.image.index.v1+json
-    # - application/vnd.docker.distribution.manifest.list.v2+json
-    # - Has .manifests array
-    if echo "$manifest" | jq --exit-status '.manifests' > /dev/null 2>&1; then
-        # Extract digests from manifests array
-        echo "$manifest" | jq --raw-output '.manifests[].digest // empty' | sed 's/^sha256://'
+    if ! ref_digests=$(get_referenced_digests "$registry_base:$first_tag"); then
+        echo "Error: Failed to inspect manifest for $registry_base:$first_tag, refusing to delete anything" >&2
+        exit 1
     fi
+
+    while IFS= read -r ref_digest; do
+        [[ -z "$ref_digest" ]] && continue
+        protected_digests["$ref_digest"]="referenced by $first_tag manifest"
+    done <<< "$ref_digests"
 }
 
 # ========== PHASE 1: COLLECT ALL VERSION DATA ==========
@@ -364,15 +375,7 @@ for version_id in "${all_version_ids[@]}"; do
         fi
 
         # Fetch manifest to protect referenced platform-specific images
-        first_tag=$(get_first_tag "$tags")
-        if [[ -n "$first_tag" ]]; then
-            echo "Inspecting manifest for protected image: $registry_base:$first_tag"
-            while IFS= read -r ref_digest; do
-                [[ -z "$ref_digest" ]] && continue
-                protected_digests["$ref_digest"]="referenced by $first_tag manifest"
-                echo "  Protected platform-specific digest: ${ref_digest:0:12}..."
-            done <<< "$(get_referenced_digests "$registry_base:$first_tag")"
-        fi
+        protect_referenced_digests "$tags"
         continue
     fi
 
@@ -410,19 +413,9 @@ for version_id in "${all_version_ids[@]}"; do
         fi
     fi
 
-    # Not a delete candidate, might reference other images
-    # Check if this is a multi-platform manifest we should inspect
-    first_tag=$(get_first_tag "$tags")
-    if [[ -n "$first_tag" ]]; then
-        while IFS= read -r ref_digest; do
-            [[ -z "$ref_digest" ]] && continue
-            # Only protect if not already marked for deletion
-            ref_version_id="${digest_to_version[$ref_digest]:-}"
-            if [[ -z "$ref_version_id" ]] || [[ -z "${delete_candidates[$ref_version_id]:-}" ]]; then
-                protected_digests["$ref_digest"]="referenced by $first_tag manifest"
-            fi
-        done <<< "$(get_referenced_digests "$registry_base:$first_tag")"
-    fi
+    # Not a delete candidate, protect everything its manifest references
+    # Unconditionally: gating on delete_candidates would make protection depend on API return order
+    protect_referenced_digests "$tags"
 done
 
 # ========== PHASE 3: FILTER DELETE CANDIDATES ==========

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Run actionlint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Check if we actually made changes
@@ -119,6 +120,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
     name: Build Rust code
     if: ${{ !startsWith(github.head_ref, 'release/') }}
     uses: ./.github/workflows/rust.yml
-    secrets: inherit
     permissions:
       checks: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,11 +143,8 @@ jobs:
             echo "Force bumping to ${bumped}"
           fi
 
-          # remove v
-          version="${bumped//v/}"
-
-          # store
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          # tags are vX.Y.Z, cargo versions are not prefixed
+          echo "version=${bumped#v}" >> "${GITHUB_OUTPUT}"
 
   docker-prepare-variables:
     name: Prepare Docker variables and version bump patch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,10 @@ jobs:
       - name: Repo has docker container?
         shell: bash
         id: determine
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   changes:
     name: Detect changes
@@ -173,8 +174,10 @@ jobs:
 
       - name: Update Cargo.toml's version
         shell: bash
+        env:
+          VERSION: ${{ needs.calculate-version.outputs.version }}
         run: |
-          cargo set-version ${{ needs.calculate-version.outputs.version }}
+          cargo set-version "${VERSION}"
 
           git diff
 
@@ -196,11 +199,10 @@ jobs:
         id: variables
         run: |
           # The application name, used in the Dockerfile
-          application_name=${{ env.IMAGE_NAME }}
           # split at the last / and keep that (kristof-mattei/repo-name -> repo-name)
-          application_name=${application_name##*/}
+          application_name="${IMAGE_NAME##*/}"
           # lowercase
-          application_name=${application_name,,}
+          application_name="${application_name,,}"
           echo "application_name=${application_name}" >> "${GITHUB_OUTPUT}"
 
           # The application's description, from Cargo.toml
@@ -215,13 +217,11 @@ jobs:
           echo "unique_tag=${unique_tag}" >> "${GITHUB_OUTPUT}"
 
           # The registry to which we'll push
-          registry=${{ env.REGISTRY }}
-          registry=${registry,,}
+          registry="${REGISTRY,,}"
           echo "registry=${registry}" >> "${GITHUB_OUTPUT}"
 
           # The final full image name, which is the registry, the owner and the repo name
-          image_name=${{ env.IMAGE_NAME }}
-          image_name=${image_name,,}
+          image_name="${IMAGE_NAME,,}"
           echo "full_image_name_remote_registry=${registry}/${image_name}" >> "${GITHUB_OUTPUT}"
 
           # The cache registry, separate from the main image registry
@@ -270,20 +270,20 @@ jobs:
         shell: bash
         id: variables
         env:
+          CACHE_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_cache_registry }}
           PLATFORM: ${{ matrix.platform }}
+          UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
           # remove slashes from platform (`amd64/v3` -> `amd64-v3`)
           platform_no_slashes="${PLATFORM//\//-}"
           echo "platform_no_slashes=${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
           # but we're only building 1 arch here, so we need to identify that container (we'll merge them later)
-          unique_tag_arch=${{ needs.docker-prepare-variables.outputs.unique_tag }}-${platform_no_slashes}
-          echo "unique_tag_arch=${unique_tag_arch}" >> "${GITHUB_OUTPUT}"
+          echo "unique_tag_arch=${UNIQUE_TAG}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
-          runner_arch="${{ runner.arch }}"
-          runner_arch="${runner_arch,,}"
-          echo "buildcache_pr_ref=${{ needs.docker-prepare-variables.outputs.full_image_name_cache_registry }}:buildcache-pr-${{ github.event.pull_request.number }}-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
-          echo "buildcache_main_ref=${{ needs.docker-prepare-variables.outputs.full_image_name_cache_registry }}:buildcache-main-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
+          runner_arch="${RUNNER_ARCH,,}"
+          echo "buildcache_pr_ref=${CACHE_IMAGE_NAME}:buildcache-pr-${{ github.event.pull_request.number }}-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
+          echo "buildcache_main_ref=${CACHE_IMAGE_NAME}:buildcache-main-${runner_arch}-${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
       - name: Set up Docker
         uses: docker/setup-docker-action@77e84dbf09b47d1e29270283c22f16145aa85ca1 # v5.4.0
@@ -439,19 +439,23 @@ jobs:
       - name: Load individual platform images from artifacts & push to registry
         shell: bash
         working-directory: ${{ steps.artifact.outputs.download-path }}
+        env:
+          ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
+          LOCAL_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}
+          UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
           platforms=()
           while IFS= read -r platform; do
             echo "Loading ${platform//\//-}:"
-            docker load --input "./${{ needs.docker-prepare-variables.outputs.unique_tag }}-${platform//\//-}.tar"
+            docker load --input "./${UNIQUE_TAG}-${platform//\//-}.tar"
 
-            full_name_with_platform=${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}-${platform//\//-}
+            full_name_with_platform="${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}-${platform//\//-}"
 
             echo "Pushing ${platform//\//-}:"
             docker push "$full_name_with_platform"
 
             platforms+=("$full_name_with_platform")
-          done <<< "${{ env.IMAGE_VARIANTS }}"
+          done <<< "${IMAGE_VARIANTS}"
 
           new_annotations=()
           while IFS= read -r annotation; do
@@ -460,28 +464,35 @@ jobs:
             annotation="${annotation/manifest:/index:}"
             new_annotations+=(--annotation)
             new_annotations+=("${annotation}")
-          done <<< "${{ steps.meta.outputs.annotations }}"
+          done <<< "${ANNOTATIONS}"
 
           # merge the platform containers in a new multiplatform one
           # with the new annotations, and push it to our local registry
-          docker buildx imagetools create "${new_annotations[@]}" --tag "${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}" \
+          docker buildx imagetools create "${new_annotations[@]}" --tag "${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}" \
             "${platforms[@]}"
 
-          echo "Inspecting ${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}:"
-          docker buildx imagetools inspect --raw "${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}"
+          echo "Inspecting ${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}:"
+          docker buildx imagetools inspect --raw "${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}"
 
       - name: Get digest of image in our local registry
         shell: bash
         id: local_image
+        env:
+          LOCAL_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}
+          UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
-          digest=$(docker buildx imagetools inspect "${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}" --format "{{json .}}" | jq --raw-output ".manifest.digest")
+          digest=$(docker buildx imagetools inspect "${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}" --format "{{json .}}" | jq --raw-output ".manifest.digest")
 
           echo "digest=${digest}" >> "${GITHUB_OUTPUT}"
 
       - name: Push from local registry to remote with new tags
         shell: bash
+        env:
+          LOCAL_IMAGE_NAME: ${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}
+          NEW_TAGS: ${{ steps.meta.outputs.tags }}
+          UNIQUE_TAG: ${{ needs.docker-prepare-variables.outputs.unique_tag }}
         run: |
-          source="docker://${{ needs.docker-prepare-variables.outputs.full_image_name_local_registry }}:${{ needs.docker-prepare-variables.outputs.unique_tag }}"
+          source="docker://${LOCAL_IMAGE_NAME}:${UNIQUE_TAG}"
 
           # skopeo's --retry-times does not retry a bare 500, so retry at the shell level too
           copy_with_retries() {
@@ -511,12 +522,14 @@ jobs:
           # try to upload all of them, if one of them fails, upload the other ones and fail
           while IFS= read -r tag; do
             copy_with_retries "${tag}" || exit_code=1
-          done <<< "${{ steps.meta.outputs.tags }}"
+          done <<< "${NEW_TAGS}"
 
           exit "${exit_code}"
 
       - name: Inspect new remote tags
         shell: bash
+        env:
+          NEW_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           while IFS= read -r new_tag; do
             echo "Inspecting ${new_tag}:"
@@ -525,7 +538,7 @@ jobs:
 
             # empty to get newline
             echo ""
-          done <<< "${{ steps.meta.outputs.tags }}"
+          done <<< "${NEW_TAGS}"
 
   docker-attest:
     name: Attest Docker container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,10 +269,11 @@ jobs:
       - name: Set variables
         shell: bash
         id: variables
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
           # remove slashes from platform (`amd64/v3` -> `amd64-v3`)
-          platform_no_slashes=${{ matrix.platform }}
-          platform_no_slashes=${platform_no_slashes//\//-}
+          platform_no_slashes="${PLATFORM//\//-}"
           echo "platform_no_slashes=${platform_no_slashes}" >> "${GITHUB_OUTPUT}"
 
           # but we're only building 1 arch here, so we need to identify that container (we'll merge them later)
@@ -307,10 +308,10 @@ jobs:
       - name: Should we set up QEMU?
         shell: bash
         id: setup_qemu
+        env:
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          base_platform="${{ matrix.platform }}"
-
-          if ! dpkg-architecture --equal "${base_platform%/*}"; then
+          if ! dpkg-architecture --equal "${PLATFORM%/*}"; then
             echo "setup_qemu=true" >> "${GITHUB_OUTPUT}"
           else
             echo "setup_qemu=false" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/compare-release-image.yml
+++ b/.github/workflows/compare-release-image.yml
@@ -24,9 +24,10 @@ jobs:
       - name: Repo has docker container?
         shell: bash
         id: determine
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   compare:
     name: Compare release image against latest

--- a/.github/workflows/compare-release-image.yml
+++ b/.github/workflows/compare-release-image.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
-  pull-requests: write
 
 env:
   REGISTRY: ghcr.io
@@ -33,6 +31,10 @@ jobs:
   compare:
     name: Compare release image against latest
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      packages: read # pull the images being compared from ghcr.io
+      pull-requests: write # docker/scout-action posts the comparison as a PR comment
     needs:
       - repo-has-container
     if: fromJSON(needs.repo-has-container.outputs.has_container) == true

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -37,6 +37,14 @@ jobs:
         with:
           show-progress: false
 
+      # The package is private, manifest inspection (skopeo/docker) needs registry credentials
+      - name: Log into registry ghcr.io
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run container cleanup
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  packages: write
   contents: read
 
 jobs:
@@ -27,6 +26,9 @@ jobs:
   cleanup-containers:
     name: Cleanup containers
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      packages: write # delete container versions
     needs:
       - repo-has-container
     if: |
@@ -57,6 +59,9 @@ jobs:
   cleanup-container-build-cache:
     name: Cleanup container build cache
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      packages: write # delete build cache versions
     needs:
       - repo-has-container
     if: |

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -19,9 +19,10 @@ jobs:
       - name: Repo has docker container?
         shell: bash
         id: determine
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   cleanup-containers:
     name: Cleanup containers

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -52,8 +52,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/scripts/cleanup-containers.sh \
-            --user ${{ github.repository_owner }} \
-            --package ${{ github.event.repository.name }} \
+            --user "${GITHUB_REPOSITORY_OWNER}" \
+            --package "${GITHUB_REPOSITORY##*/}" \
             --yes
 
   cleanup-container-build-cache:
@@ -77,6 +77,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/scripts/cleanup-container-build-cache.sh \
-            --user ${{ github.repository_owner }} \
-            --package ${{ github.event.repository.name }}-cache \
+            --user "${GITHUB_REPOSITORY_OWNER}" \
+            --package "${GITHUB_REPOSITORY##*/}-cache" \
             --yes

--- a/.github/workflows/container-cleanup.yml
+++ b/.github/workflows/container-cleanup.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       # The package is private, manifest inspection (skopeo/docker) needs registry credentials
@@ -70,6 +71,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Run container build cache cleanup

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Install pnpm

--- a/.github/workflows/graduate-release.yml
+++ b/.github/workflows/graduate-release.yml
@@ -41,12 +41,13 @@ jobs:
             echo "prerelease=true" >> "${GITHUB_OUTPUT}"
           fi
 
+      # zizmor: ignore[artipacked] the tag steps below read from the remote, which needs the credential in .git/config
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: true
           show-progress: false
-          token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
 
       - name: Create tag
         shell: bash

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
           fetch-depth: 0
 

--- a/.github/workflows/machete.yml
+++ b/.github/workflows/machete.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Set up toolchain

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -36,12 +36,11 @@ jobs:
       - name: Determine version
         id: version
         shell: bash
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          version="${{ github.ref_name }}"
-          # remove v
-          version="${version//v/}"
-
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          # tags are vX.Y.Z, crates.io versions are not prefixed
+          echo "version=${REF_NAME#v}" >> "${GITHUB_OUTPUT}"
 
   publish-crate:
     name: Publish crate

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -29,9 +29,10 @@ jobs:
       - name: Repo has crate?
         id: determine
         shell: bash
+        env:
+          HAS_CRATE: ${{ vars.HAS_CRATE }}
         run: |
-          has_crate="${{ vars.HAS_CRATE }}"
-          echo "has_crate=${has_crate:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_crate=${HAS_CRATE:-false}" >> "${GITHUB_OUTPUT}"
 
       - name: Determine version
         id: version
@@ -86,8 +87,10 @@ jobs:
 
       - name: Set version in Cargo.toml / Cargo.lock
         shell: bash
+        env:
+          VERSION: ${{ needs.repo-has-crate.outputs.version }}
         run: |
-          cargo set-version "${{ needs.repo-has-crate.outputs.version }}"
+          cargo set-version "${VERSION}"
 
           git diff
 

--- a/.github/workflows/publish-crate-after-release.yml
+++ b/.github/workflows/publish-crate-after-release.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Set up mold

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,11 +225,10 @@ jobs:
       - name: Open or update pull request
         shell: bash
         env:
+          BRANCH: ${{ steps.release.outputs.branch }}
           GH_TOKEN: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
+          RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
         run: |
-          branch="${{ steps.release.outputs.branch }}"
-          release_version="${{ steps.release.outputs.release_version }}"
-
           # Truncate diff-CHANGELOG.md if it exceeds GitHub's PR character body limit
           max_length=65536
           truncation_message=$'\n\n---\n\n> **Note:** Changelog was truncated because it exceeded GitHub'"'"'s 65,536 character limit.'
@@ -243,7 +242,7 @@ jobs:
           fi
 
           # Check if a PR already exists for this branch
-          existing_pr=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')
+          existing_pr=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
 
           if [ -n "$existing_pr" ]; then
             # gh pr edit needs read:org, even for --body (cli/cli#13575).
@@ -253,29 +252,28 @@ jobs:
           else
             gh pr create \
               --base main \
-              --head "${branch}" \
-              --title "chore(release): Release ${release_version}" \
+              --head "${BRANCH}" \
+              --title "chore(release): Release ${RELEASE_VERSION}" \
               --body-file diff-CHANGELOG.md
           fi
 
           if [ "${{ inputs.auto_merge }}" = "true" ]; then
-            gh pr merge "${branch}" --auto --merge
+            gh pr merge "${BRANCH}" --auto --merge
           fi
 
       - name: Clean up stranded branches
         if: ${{ (failure() || cancelled()) && steps.release.outputs.branch != '' }}
         shell: bash
         env:
+          BRANCH: ${{ steps.release.outputs.branch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          branch="${{ steps.release.outputs.branch }}"
-
-          git push origin --delete "${branch}-staging" || true
+          git push origin --delete "${BRANCH}-staging" || true
 
           # Deleting the release branch would close its PR, so keep it when one exists.
           # A failing `gh pr list` fails the step (set -e) instead of counting as "no PR".
-          open_pr=$(gh pr list --head "${branch}" --state open --json number --jq '.[0].number // empty')
+          open_pr=$(gh pr list --head "${BRANCH}" --state open --json number --jq '.[0].number // empty')
 
           if [ -z "${open_pr}" ]; then
-            git push origin --delete "${branch}" || true
+            git push origin --delete "${BRANCH}" || true
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,12 @@ jobs:
           echo "Only to be executed on main"
           exit 1
 
+      # zizmor: ignore[artipacked] the release branch is pushed with this credential, see the release step
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: true
           show-progress: false
           token: ${{ secrets.TOKEN_TO_TRIGGER_SUBSEQUENT_WORKFLOWS }}
 

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -24,8 +24,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
-  pull-requests: read
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -76,6 +74,10 @@ jobs:
           - "ubuntu-24.04-arm"
         platform: ${{ fromJSON(needs.architectures.outputs.architectures) }}
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
+      packages: write # retag build cache images in ghcr.io
+      pull-requests: read # resolve the PR that produced the incoming merge commit
     needs:
       - architectures
       - repo-has-container

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
           fetch-depth: 2
 

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -44,9 +44,10 @@ jobs:
       - name: Repo has docker container?
         id: determine
         shell: bash
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   architectures:
     name: Build matrix
@@ -106,13 +107,10 @@ jobs:
         run: |
           platform_no_slashes="${PLATFORM//\//-}"
 
-          image_name="${{ env.IMAGE_NAME }}"
-          image_name="${image_name,,}"
-          registry="${{ env.REGISTRY }}"
-          registry="${registry,,}"
+          image_name="${IMAGE_NAME,,}"
+          registry="${REGISTRY,,}"
 
-          runner_arch="${{ runner.arch }}"
-          runner_arch="${runner_arch,,}"
+          runner_arch="${RUNNER_ARCH,,}"
 
           target_ref="${registry}/${image_name}-cache:buildcache-main-${runner_arch}-${platform_no_slashes}"
 

--- a/.github/workflows/retag-build-cache-after-pr.yml
+++ b/.github/workflows/retag-build-cache-after-pr.yml
@@ -102,9 +102,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          platform_no_slashes="${{ matrix.platform }}"
-          platform_no_slashes="${platform_no_slashes//\//-}"
+          platform_no_slashes="${PLATFORM//\//-}"
 
           image_name="${{ env.IMAGE_NAME }}"
           image_name="${image_name,,}"

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -45,9 +45,10 @@ jobs:
       - name: Repo has docker container?
         id: determine
         shell: bash
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   retag-containers:
     name: Retag the containers
@@ -138,13 +139,13 @@ jobs:
             --jq '.[] | .metadata.container.tags[]')
 
           # search for the PR tag, there can only be zero or one match
-          pr_tag_found=$(echo "${all_tags}" | grep -c "^${{ env.PR_TAG }}\$") || true
+          pr_tag_found=$(echo "${all_tags}" | grep -c "^${PR_TAG}\$") || true
 
           if [ "${pr_tag_found}" -eq 1 ]
           then
             echo "Incoming PR produced a Docker image"
 
-            echo "OLD_TAG=${{ env.PR_TAG }}" >> "${GITHUB_ENV}"
+            echo "OLD_TAG=${PR_TAG}" >> "${GITHUB_ENV}"
             echo "SUFFIX=actual" >> "${GITHUB_ENV}"
           else
             # If we don't have an old tag, then the incoming PR didn't produce a container.
@@ -155,11 +156,11 @@ jobs:
             # so we find the last commit that github processed before this one
             # which will have gone through the same retagging process
             # and use that sha as our key to find the Docker container related to that commit
-            old_tag=$(echo "${all_tags}" | grep "^sha-${{ env.BASE_SHA }}-.*\$") || true # .* is actual or retag
+            old_tag=$(echo "${all_tags}" | grep "^sha-${BASE_SHA}-.*\$") || true # .* is actual or retag
 
             if [ -z "${old_tag}" ]
             then
-              echo "::error::No matching source tag found for base SHA ${{ env.BASE_SHA }}"
+              echo "::error::No matching source tag found for base SHA ${BASE_SHA}"
               exit 1
             fi
 
@@ -198,8 +199,10 @@ jobs:
 
       - name: Actually re-tag the container
         shell: bash
+        env:
+          NEW_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r new_tag
+          echo "${NEW_TAGS}" | while IFS= read -r new_tag
             do
               docker buildx imagetools create --tag "${new_tag}" "${FULL_IMAGE_NAME}:${OLD_TAG}"
           done
@@ -214,8 +217,10 @@ jobs:
       - name: Copy the container to Docker Hub
         if: env.DOCKERHUB_IMAGE_NAME != ''
         shell: bash
+        env:
+          NEW_TAGS: ${{ steps.meta-dockerhub.outputs.tags }}
         run: |
-          echo "${{ steps.meta-dockerhub.outputs.tags }}" | while IFS= read -r new_tag
+          echo "${NEW_TAGS}" | while IFS= read -r new_tag
             do
               skopeo copy --all --preserve-digests --command-timeout 70s --retry-times 5 "docker://${FULL_IMAGE_NAME}:${OLD_TAG}" "docker://${new_tag}"
           done

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -22,11 +22,7 @@ concurrency:
   cancel-in-progress: false # no we need them
 
 permissions:
-  artifact-metadata: write
-  attestations: write
   contents: read
-  id-token: write
-  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -56,6 +52,12 @@ jobs:
   retag-containers:
     name: Retag the containers
     runs-on: ubuntu-26.04
+    permissions:
+      artifact-metadata: write # actions/attest
+      attestations: write # actions/attest
+      contents: read
+      id-token: write # actions/attest
+      packages: write # retag images in ghcr.io
     needs:
       - repo-has-container
     if: |

--- a/.github/workflows/retag-containers-after-push.yml
+++ b/.github/workflows/retag-containers-after-push.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
           fetch-depth: 2
 

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -33,9 +33,10 @@ jobs:
       - name: Repo has docker container?
         id: determine
         shell: bash
+        env:
+          HAS_CONTAINER: ${{ vars.HAS_CONTAINER }}
         run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
+          echo "has_container=${HAS_CONTAINER:-false}" >> "${GITHUB_OUTPUT}"
 
   retag-containers:
     name: Retag the containers
@@ -148,8 +149,10 @@ jobs:
 
       - name: Actually re-tag the container
         shell: bash
+        env:
+          NEW_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          echo "${{ steps.meta.outputs.tags }}" | while IFS= read -r new_tag
+          echo "${NEW_TAGS}" | while IFS= read -r new_tag
             do
               docker buildx imagetools create --tag "${new_tag}" "${FULL_IMAGE_NAME}:${OLD_TAG}"
           done
@@ -164,10 +167,13 @@ jobs:
       - name: Copy the container to Docker Hub
         if: env.DOCKERHUB_IMAGE_NAME != ''
         shell: bash
+        env:
+          DIGEST: ${{ steps.digest.outputs.digest }}
+          NEW_TAGS: ${{ steps.meta-dockerhub.outputs.tags }}
         run: |
-          echo "${{ steps.meta-dockerhub.outputs.tags }}" | while IFS= read -r new_tag
+          echo "${NEW_TAGS}" | while IFS= read -r new_tag
             do
-              if [ "$(skopeo inspect --format '{{ .Digest }}' --no-tags "docker://${new_tag}" 2>/dev/null)" = "${{ steps.digest.outputs.digest }}" ]; then
+              if [ "$(skopeo inspect --format '{{ .Digest }}' --no-tags "docker://${new_tag}" 2>/dev/null)" = "${DIGEST}" ]; then
                 echo "${new_tag} already exists, skipping"
                 continue
               fi

--- a/.github/workflows/retag-containers-after-release.yml
+++ b/.github/workflows/retag-containers-after-release.yml
@@ -12,11 +12,7 @@ concurrency:
   cancel-in-progress: false # last one must win in case of multiple releases
 
 permissions:
-  artifact-metadata: write
-  attestations: write
   contents: read
-  id-token: write
-  packages: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -44,6 +40,12 @@ jobs:
   retag-containers:
     name: Retag the containers
     runs-on: ubuntu-26.04
+    permissions:
+      artifact-metadata: write # actions/attest
+      attestations: write # actions/attest
+      contents: read
+      id-token: write # actions/attest
+      packages: write # retag images in ghcr.io
     needs:
       - repo-has-container
     if: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,6 +29,7 @@ jobs:
         name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Check if we actually made changes

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           show-progress: false
 
       - name: Make sure dictionary words are sorted and unique

--- a/project-words.txt
+++ b/project-words.txt
@@ -44,6 +44,7 @@ topo
 trixie
 TRUNC
 uninlined
+uninspectable
 unseparated
 usernamehw
 vadimcn

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,6 +1,7 @@
 adduser
 appgroup
 appuser
+artipacked
 bkeepers
 buildcache
 cinstrument
@@ -48,3 +49,4 @@ uninspectable
 unseparated
 usernamehw
 vadimcn
+zizmor

--- a/project-words.txt
+++ b/project-words.txt
@@ -5,6 +5,7 @@ artipacked
 bkeepers
 buildcache
 cinstrument
+cliffignore
 ctarget
 cttc
 cves
@@ -24,6 +25,7 @@ multiplatform
 mypy
 nextest
 nvmrc
+oneline
 pathbuf
 postprocessors
 prereleased


### PR DESCRIPTION
- **fix(ci): authenticate container cleanup against ghcr.io and stop treating failed manifest inspection as an image without children**
- **fix(ci): scope write permissions to the jobs that use them and stop interpolating refs into `run` blocks**
- **fix(ci): strip only the leading `v` from the release tag**
- **fix(ci): stop persisting checkout credentials where no step talks to a remote**
- **fix(ci): stop passing every repo secret to `rust.yml`**
- **fix(ci): pass `matrix.platform` through the environment**
- **fix(ci): pass template expansions into `run` blocks through the environment**
- **fix(ci): strip only the leading `v` from the calculated version**
