### PR TITLE
ci: set `GH_REPO` and retry transient errors in the release base container gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,11 +89,13 @@ jobs:
         shell: bash
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_REPO: ${{ github.repository }} # no checkout, so gh cannot infer the repository from a git remote
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Release PRs build no container, so the retag run for their merge commit falls back to
           # the `sha-<base>-*` tag, which the retag run for the base commit creates.
           # Merging before that run has finished makes the merge commit's retag fail.
+          url=""
           conclusion=""
 
           for attempt in $(seq 1 30); do
@@ -103,17 +105,18 @@ jobs:
 
             echo "Looking for the retag run of ${BASE_SHA} (attempt ${attempt} of 30)"
 
+            # || true: no run yet, or a transient api error, both mean retry
             run=$(gh run list \
               --workflow retag-containers-after-push.yml \
               --event push \
               --commit "${BASE_SHA}" \
               --limit 1 \
               --json status,conclusion,url \
-              --jq '.[0] // empty')
+              --jq '.[0] // empty') || true
 
             if [ -z "${run}" ]; then
-              echo "::error::No retag run found for base commit ${BASE_SHA}"
-              exit 1
+              echo "No retag run found yet"
+              continue
             fi
 
             status=$(jq --raw-output '.status' <<< "${run}")
@@ -126,6 +129,11 @@ jobs:
 
             echo "Retag run ${url} is ${status}"
           done
+
+          if [ -z "${url}" ]; then
+            echo "::error::No retag run found for base commit ${BASE_SHA}"
+            exit 1
+          fi
 
           if [ -z "${conclusion}" ]; then
             echo "::error::Retag run ${url} for base commit ${BASE_SHA} did not complete in time"


### PR DESCRIPTION
The job has no checkout, so `gh run list` failed with "failed to determine base repo" before querying anything. The step runs under `set -e`, so that exit, like any transient API error from `gh run list`, aborted the step on the first attempt instead of letting the loop retry for up to 30 attempts.
