### PR TITLE
ci(release): read the ballot from the live PR body and stop rewriting it on a toggle

### DIFF
--- a/.github/actions/compute-changelog-selection/action.yml
+++ b/.github/actions/compute-changelog-selection/action.yml
@@ -1,10 +1,13 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-action.json
 name: Compute changelog selection
-description: Derive the .cliffignore contents from the release PR body's ballot checkboxes
+description: Derive the .cliffignore contents from the ballot checkboxes in the live body of the release PR
 
 inputs:
-  body:
-    description: Release PR body containing the ballot
+  pull-request:
+    description: Number of the release PR
+    required: true
+  token:
+    description: Token with read access to the pull request
     required: true
   head:
     description: Commit whose selection is being computed
@@ -26,14 +29,16 @@ runs:
       id: compute
       shell: bash
       env:
-        BODY: ${{ inputs.body }}
+        GH_TOKEN: ${{ inputs.token }}
+        PR_NUMBER: ${{ inputs.pull-request }}
         HEAD_SHA: ${{ inputs.head }}
       run: |
         # The release commit and the merge commit of its PR both have the base main commit as their first parent
         base_sha=$(git rev-parse "${HEAD_SHA}~1")
         echo "base-sha=${base_sha}" >> "${GITHUB_OUTPUT}"
 
-        printf '%s' "${BODY}" > "${RUNNER_TEMP}/body.md"
+        # A toggle made after the event is only in the live body, and a re-run has to judge the current ballot rather than the payload that triggered it.
+        gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""' > "${RUNNER_TEMP}/body.md"
 
         # A ballot line ends with the entry's commit link, `- [x] ... ([abc1234](https://.../commit/<sha>))`
         # The SHA is taken from that trailing link, so a /commit/ URL inside a commit subject is ignored. A hand-edited [X] counts as checked.

--- a/.github/actions/render-ballot-body/action.yml
+++ b/.github/actions/render-ballot-body/action.yml
@@ -7,7 +7,7 @@ inputs:
     description: git-cliff context JSON listing every entry, including the excluded ones
     required: true
   compare-to:
-    description: Commit the changelog's compare link points at
+    description: Ref the changelog's compare link points at
     required: true
   excluded-file:
     description: File of commit SHAs to render unchecked. When empty or missing, every entry stays checked.
@@ -32,7 +32,7 @@ runs:
       run: |
         body_file="${RUNNER_TEMP}/ballot-body.md"
 
-        # The release tag does not exist until the PR is merged, so the compare link points at the release commit instead
+        # The release tag does not exist until the PR is merged, so the compare link points at the release branch instead
         jq --arg sha "${COMPARE_TO}" '.[0].extra = {compare_to: $sha}' "${CONTEXT_FILE}" > "${RUNNER_TEMP}/diff-context.json"
 
         # The context was built without .cliffignore, so the ballot lists every commit, including the ones CHANGELOG.md excludes

--- a/.github/workflows/apply-changelog-selection.yml
+++ b/.github/workflows/apply-changelog-selection.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-26.04
     permissions:
       contents: write # to rebuild the release commit via createCommitOnBranch
-      pull-requests: write # to refresh the release PR body
-    # Same group as the Release workflow for this pre-release type, because both force-push the release branch and rewrite the PR body.
+      pull-requests: read # to read the live PR body
+    # Same group as the Release workflow for this pre-release type, because both force-push the release branch.
     # The group is on the job so that an edit to a non-release PR is skipped without entering it.
     concurrency:
       group: "release-${{ (contains(github.event.pull_request.head.ref, '-alpha.') && 'alpha') || (contains(github.event.pull_request.head.ref, '-beta.') && 'beta') || (contains(github.event.pull_request.head.ref, '-rc.') && 'rc') || 'none' }}"
-      cancel-in-progress: false # a cancelled run could stop between the force-push and the PR body update
+      cancel-in-progress: false # a newer run would also cancel a Release run in the same group
     if: |
       github.event.pull_request.state == 'open' &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -45,11 +45,12 @@ jobs:
         with:
           tool: git-cliff
 
-      - name: Compute selection from the PR body
+      - name: Compute selection from the live PR body
         id: ballot
         uses: $/.github/actions/compute-changelog-selection
         with:
-          body: ${{ github.event.pull_request.body }}
+          pull-request: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compare with the committed .cliffignore
         shell: bash
@@ -80,10 +81,6 @@ jobs:
           TAG: ${{ steps.selection.outputs.tag }}
           SELECTION_FILE: ${{ steps.ballot.outputs.selection-file }}
         run: |
-          # git-cliff applies .cliffignore to --context as well, which would leave the hidden commits off the ballot
-          rm --force .cliffignore
-          git-cliff --context --unreleased --tag "${TAG}" > ballot-context.json
-
           # The release commit has to overwrite the .cliffignore inherited from main, so the file is copied even when empty
           cp "${SELECTION_FILE}" .cliffignore
 
@@ -101,27 +98,6 @@ jobs:
           staging-suffix: -selection-staging
           # GITHUB_TOKEN attributes the commit to github-actions[bot]
           token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Render the ballot
-        id: ballot-body
-        if: steps.selection.outputs.changed == 'true'
-        uses: $/.github/actions/render-ballot-body
-        with:
-          context-file: ballot-context.json
-          compare-to: ${{ steps.commit.outputs.commit-sha }}
-          excluded-file: .cliffignore
-
-      - name: Refresh pull request body
-        if: steps.selection.outputs.changed == 'true'
-        shell: bash
-        env:
-          # An edit made with GITHUB_TOKEN does not fire pull_request events, so this update does not trigger this workflow again
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          BODY_FILE: ${{ steps.ballot-body.outputs.body-file }}
-        run: |
-          # gh pr edit needs read:org even for --body (cli/cli#13575), so the body is set with a REST PATCH
-          gh api --method PATCH --silent "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --field "body=@${BODY_FILE}"
 
       - name: Clean up stranded staging branch
         if: failure() || cancelled()

--- a/.github/workflows/graduate-release.yml
+++ b/.github/workflows/graduate-release.yml
@@ -55,27 +55,12 @@ jobs:
           persist-credentials: true
           show-progress: false
 
-      - name: Fetch the final ballot
-        id: final-ballot
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          # A toggle made just before the merge may be missing from the event payload, so the body is fetched live
-          delimiter=$(openssl rand -hex 16)
-
-          {
-            echo "body<<${delimiter}"
-            gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""'
-            echo "${delimiter}"
-          } >> "${GITHUB_OUTPUT}"
-
       - name: Compute selection from the final ballot
         id: ballot
         uses: $/.github/actions/compute-changelog-selection
         with:
-          body: ${{ steps.final-ballot.outputs.body }}
+          pull-request: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           head: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Compare the merged .cliffignore with the final ballot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
           - rc
 
 concurrency:
-  # Same group as the apply workflow for this pre-release type, because both force-push the release branch and rewrite the PR body
+  # Same group as the apply workflow for this pre-release type, because both force-push the release branch
   group: "release-${{ inputs.prerelease }}"
   cancel-in-progress: false # this job force-pushes branches and opens PRs, let it finish
 
@@ -198,29 +198,31 @@ jobs:
       - name: Write .cliffignore and generate the changelog
         shell: bash
         env:
+          BRANCH: ${{ steps.release.outputs.branch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # git-cliff reads GITHUB_TOKEN from the environment
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: ${{ steps.release.outputs.branch }}
           RELEASE_VERSION: ${{ steps.release.outputs.release_version }}
           SIBLINGS_FILE: ${{ steps.siblings.outputs.file }}
         run: |
           # Only a checked entry appears in the changelog, so every unreleased commit starts excluded
           jq --raw-output '.[0].commits[].id' ballot-context.json | sort --unique > "${RUNNER_TEMP}/unreleased.txt"
 
-          # Checked entries carry over from an earlier run of this release and from the release PRs this run supersedes. Their CHANGELOG.md lists only the checked entries.
+          # Checked entries carry over from the live bodies of the open release PRs of this type, including the PR of this branch. A toggle is in the body before the rebuild puts it in CHANGELOG.md, so the body is the source.
           : > "${RUNNER_TEMP}/checked.txt"
 
-          {
-            if git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null; then
-              echo "${BRANCH}"
-            fi
+          while read -r pr_number _; do
+            gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" --jq '.body // ""' \
+              | grep --perl-regexp --only-matching '^- \[[xX]\] .*/commit/\K[0-9a-f]{40}(?=\)\)\r?$)' >> "${RUNNER_TEMP}/checked.txt" || true
+          done < "${SIBLINGS_FILE}"
 
-            cut --delimiter=" " --fields=2 "${SIBLINGS_FILE}"
-          } | sort --unique | while IFS= read -r source_branch; do
-            git fetch origin "refs/heads/${source_branch}"
+          # When the PR of a release branch was closed by hand, the body is gone and a toggle cannot be pending, so the branch's CHANGELOG.md is the latest selection
+          if ! cut --delimiter=" " --fields=2 "${SIBLINGS_FILE}" | grep --quiet --fixed-strings --line-regexp "${BRANCH}" \
+            && git ls-remote --exit-code --heads origin "${BRANCH}" > /dev/null; then
+            git fetch origin "refs/heads/${BRANCH}"
             git show "FETCH_HEAD:CHANGELOG.md" 2> /dev/null \
               | grep --perl-regexp --only-matching '/commit/\K[0-9a-f]{40}(?=\)\)$)' >> "${RUNNER_TEMP}/checked.txt" || true
-          done
+          fi
 
           # Exclusions accumulate across releases, so the copy on main is the starting point
           git show HEAD:.cliffignore > .cliffignore 2> /dev/null || : > .cliffignore
@@ -246,7 +248,7 @@ jobs:
         uses: $/.github/actions/render-ballot-body
         with:
           context-file: ballot-context.json
-          compare-to: ${{ steps.commit.outputs.commit-sha }}
+          compare-to: ${{ steps.release.outputs.branch }}
           excluded-file: .cliffignore
 
       - name: Open or update pull request

--- a/.github/workflows/verify-changelog-selection.yml
+++ b/.github/workflows/verify-changelog-selection.yml
@@ -22,6 +22,9 @@ jobs:
   verify:
     name: Verify changelog selection
     runs-on: ubuntu-26.04
+    permissions:
+      contents: read
+      pull-requests: read # to read the live PR body
     # The check is required on every PR, and a skipped job satisfies it on the PRs without a ballot
     if: startsWith(github.event.pull_request.head.ref, 'release/v')
     steps:
@@ -92,11 +95,12 @@ jobs:
 
           echo "::notice::${checked} changelog entries"
 
-      - name: Compute selection from the PR body
+      - name: Compute selection from the live PR body
         id: ballot
         uses: $/.github/actions/compute-changelog-selection
         with:
-          body: ${{ github.event.pull_request.body }}
+          pull-request: ${{ github.event.pull_request.number }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Compare with the committed .cliffignore
         shell: bash


### PR DESCRIPTION
A toggle made while an apply run was in flight was reverted when the run rewrote the body from its stale event payload.
